### PR TITLE
Add  `working_hour.total_working_duration` documentation

### DIFF
--- a/positions/working_hours.md
+++ b/positions/working_hours.md
@@ -43,9 +43,11 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
 [
   {
     "starttime": "2020-02-01T10:04:00+01:00",
-    "endtime": "2020-02-01T18:04:00+01:00",
-    "pauses_duration": "01:15",
-    "total_working_hours": "07.75",
+    "endtime": "2020-02-01T19:04:00+01:00",
+    "pauses_duration": "1.25",
+    "pauses_duration_in_hh_mm": "01:15",
+    "working_duration": "7.75",
+    "working_duration_in_hh_mm": "07:45",
     "remarks": "Started earlier",
     "labels": "[\"Mittagessen, 12 CHF\", \"Nachtzulage\"]",
     "confirmed": false
@@ -55,12 +57,14 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
 
 #### Item attributes
 
-| Key                   | Type      | Can be null? | Description                                | Example values               |
-| --------------------- | --------- | ------------ | ------------------------------------------ | ---------------------------- |
-| `starttime`           | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T10:04:00+01:00`  |
-| `endtime`             | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T18:04:00+01:00`  |
-| `pauses_duration`     | `string`  | no           | Duration in format `HH:MM`                 | `01:15`                      |
-| `total_working_hours` | `string`  | no           | Total duration as a decimal number         | `07.75`                      |
-| `remarks`             | `string`  | yes          | A comment concerning the working_hour      | `Started earlier`            |
-| `lables`              | `array`   | yes          | A json array containing labels as strings  | `'["String a", "String b"]'` |
-| `confirmed`           | `boolean` | no           | Indicates if working_hour is confirmed     | `true`                       |
+| Key                         | Type      | Can be null? | Description                                | Example values               |
+| --------------------------- | --------- | ------------ | ------------------------------------------ | ---------------------------- |
+| `starttime`                 | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T10:04:00+01:00`  |
+| `endtime`                   | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T18:04:00+01:00`  |
+| `pauses_duration`           | `string`  | no           | Pauses duration as decimal number          | `1.25`                       |
+| `pauses_duration_in_hh_mm`  | `string`  | no           | Pauses duration in format `HH:MM`          | `01:15`                      |
+| `working_duration`          | `string`  | no           | Working hour duration as a decimal number  | `7.75`                       |
+| `working_duration_in_hh_mm` | `string`  | no           | Working hour duration in format `HH:MM`    | `07:45`                      |
+| `remarks`                   | `string`  | yes          | A comment concerning the working_hour      | `Started earlier`            |
+| `lables`                    | `array`   | yes          | A json array containing labels as strings  | `'["String a", "String b"]'` |
+| `confirmed`                 | `boolean` | no           | Indicates if working_hour is confirmed     | `true`                       |

--- a/positions/working_hours.md
+++ b/positions/working_hours.md
@@ -57,14 +57,14 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
 
 #### Item attributes
 
-| Key                         | Type      | Can be null? | Description                                | Example values               |
-| --------------------------- | --------- | ------------ | ------------------------------------------ | ---------------------------- |
-| `starttime`                 | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T10:04:00+01:00`  |
-| `endtime`                   | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T18:04:00+01:00`  |
-| `pauses_duration`           | `number`  | no           | Pauses duration as decimal number          | `1.25`                       |
-| `pauses_duration_in_hh_mm`  | `string`  | no           | Pauses duration in format `HH:MM`          | `"01:15"`                      |
-| `working_duration`          | `number`  | no           | Working hour duration as a decimal number  | `7.75`                       |
-| `working_duration_in_hh_mm` | `string`  | no           | Working hour duration in format `HH:MM`    | `"07:45"`                      |
-| `remarks`                   | `string`  | yes          | A comment concerning the working_hour      | `Started earlier`            |
-| `lables`                    | `array`   | yes          | A json array containing labels as strings  | `'["String a", "String b"]'` |
-| `confirmed`                 | `boolean` | no           | Indicates if working_hour is confirmed     | `true`                       |
+| Key                         | Type      | Can be null? | Description                                                | Example values               |
+| --------------------------- | --------- | ------------ | ---------------------------------------------------------- | ---------------------------- |
+| `starttime`                 | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm`                 | `2020-02-01T10:04:00+01:00`  |
+| `endtime`                   | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm`                 | `2020-02-01T18:04:00+01:00`  |
+| `pauses_duration`           | `number`  | no           | Pauses duration as decimal number                          | `1.25`                       |
+| `pauses_duration_in_hh_mm`  | `string`  | no           | Pauses duration in format `HH:MM`                          | `"01:15"`                    |
+| `working_duration`          | `number`  | no           | Working hour duration excluding pauses as a decimal number | `7.75`                       |
+| `working_duration_in_hh_mm` | `string`  | no           | Working hour duration excluding pauses in format `HH:MM`   | `"07:45"`                    |
+| `remarks`                   | `string`  | yes          | A comment concerning the working_hour                      | `Started earlier`            |
+| `lables`                    | `array`   | yes          | A json array containing labels as strings                  | `'["String a", "String b"]'` |
+| `confirmed`                 | `boolean` | no           | Indicates if working_hour is confirmed                     | `true`                       |

--- a/positions/working_hours.md
+++ b/positions/working_hours.md
@@ -61,10 +61,10 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
 | --------------------------- | --------- | ------------ | ------------------------------------------ | ---------------------------- |
 | `starttime`                 | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T10:04:00+01:00`  |
 | `endtime`                   | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T18:04:00+01:00`  |
-| `pauses_duration`           | `string`  | no           | Pauses duration as decimal number          | `1.25`                       |
-| `pauses_duration_in_hh_mm`  | `string`  | no           | Pauses duration in format `HH:MM`          | `01:15`                      |
-| `working_duration`          | `string`  | no           | Working hour duration as a decimal number  | `7.75`                       |
-| `working_duration_in_hh_mm` | `string`  | no           | Working hour duration in format `HH:MM`    | `07:45`                      |
+| `pauses_duration`           | `number`  | no           | Pauses duration as decimal number          | `1.25`                       |
+| `pauses_duration_in_hh_mm`  | `string`  | no           | Pauses duration in format `HH:MM`          | `"01:15"`                      |
+| `working_duration`          | `number`  | no           | Working hour duration as a decimal number  | `7.75`                       |
+| `working_duration_in_hh_mm` | `string`  | no           | Working hour duration in format `HH:MM`    | `"07:45"`                      |
 | `remarks`                   | `string`  | yes          | A comment concerning the working_hour      | `Started earlier`            |
 | `lables`                    | `array`   | yes          | A json array containing labels as strings  | `'["String a", "String b"]'` |
 | `confirmed`                 | `boolean` | no           | Indicates if working_hour is confirmed     | `true`                       |

--- a/positions/working_hours.md
+++ b/positions/working_hours.md
@@ -4,7 +4,6 @@ In this document:
 
 - [All Working Hours](#all-working-Hours)
 
-
 Related
 
 - [Single position](../positions.md#single-position)
@@ -24,7 +23,7 @@ Get all Working Hours of given Position.
 #### Params
 
 | Param          | Description                                         |
-|----------------|-----------------------------------------------------|
+| -------------- | --------------------------------------------------- |
 | `:position_id` | ID of a position (see [Positions](../positions.md)) |
 | `from`         | Startdate in format ISO 8601 `2021-05-01`           |
 | `to`           | Enddate in format ISO 8601 `2021-05-31`             |
@@ -46,8 +45,9 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
     "starttime": "2020-02-01T10:04:00+01:00",
     "endtime": "2020-02-01T18:04:00+01:00",
     "pauses_duration": "01:15",
+    "total_working_hours": "07.75",
     "remarks": "Started earlier",
-    "labels": '["Mittagessen, 12 CHF", "Nachtzulage"]',
+    "labels": "[\"Mittagessen, 12 CHF\", \"Nachtzulage\"]",
     "confirmed": false
   }
 ]
@@ -55,11 +55,12 @@ Response is an `Array` of Working Hours ordered by `date` chronologically, `star
 
 #### Item attributes
 
-| Key              | Type     | Can be null? | Description                                 | Example values               |
-|------------------|----------|--------------|---------------------------------------------|------------------------------|
-| `starttime`      | `string` | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm`  | `2020-02-01T10:04:00+01:00`  |
-| `endtime`        | `string` | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm`  | `2020-02-01T18:04:00+01:00`  |
-| `pauses_duration`| `string` | no           | Duration in format `HH:MM`                  | `01:15`                      |
-| `remarks`        | `string` | yes          | A comment concerning the working_hour       | `Started earlier`            |
-| `lables`         | `array`  | yes          | A json array containing  labels as strings  | `'["String a", "String b"]'` |
-| `confirmed`      | `boolean`| no           | Indicates if working_hour is confirmed      | `true`                       |
+| Key                   | Type      | Can be null? | Description                                | Example values               |
+| --------------------- | --------- | ------------ | ------------------------------------------ | ---------------------------- |
+| `starttime`           | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T10:04:00+01:00`  |
+| `endtime`             | `string`  | no           | Time in format `YYYY-MM-DDThh:mm:ss±hh:mm` | `2020-02-01T18:04:00+01:00`  |
+| `pauses_duration`     | `string`  | no           | Duration in format `HH:MM`                 | `01:15`                      |
+| `total_working_hours` | `string`  | no           | Total duration as a decimal number         | `07.75`                      |
+| `remarks`             | `string`  | yes          | A comment concerning the working_hour      | `Started earlier`            |
+| `lables`              | `array`   | yes          | A json array containing labels as strings  | `'["String a", "String b"]'` |
+| `confirmed`           | `boolean` | no           | Indicates if working_hour is confirmed     | `true`                       |


### PR DESCRIPTION
Adds documentation for the new field `working_hour.total_working_hours`

See also https://github.com/pia-planer/pia-app/pull/260